### PR TITLE
Call `autounstash` automatically/always when leaving a directory

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -266,6 +266,10 @@ _autoenv_chpwd_handler() {
         if _autoenv_check_authorized_env_file $env_file_leave; then
           _autoenv_source $env_file_leave leave $prev_dir
         fi
+
+        # Unstash any autostash'd stuff.
+        varstash_dir=$prev_dir autounstash
+
         _autoenv_stack_entered_remove $prev_file
       fi
     done

--- a/tests/varstash.t
+++ b/tests/varstash.t
@@ -6,7 +6,7 @@ Setup test environment.
 
   $ mkdir sub
   $ cd sub
-  $ echo 'echo ENTER; autostash FOO=baz' > $AUTOENV_FILE_ENTER
+  $ echo 'echo ENTER; autostash FOO=changed' > $AUTOENV_FILE_ENTER
   $ echo 'echo LEAVE; autounstash' > $AUTOENV_FILE_LEAVE
 
 Manually create auth file
@@ -15,18 +15,75 @@ Manually create auth file
 
 Set environment variable.
 
-  $ FOO=bar
+  $ FOO=orig
 
 Activating the env stashes it and applies a new value.
 
   $ cd .
   ENTER
   $ echo $FOO
-  baz
+  changed
 
 Leaving the directory unstashes it.
 
   $ cd ..
   LEAVE
   $ echo $FOO
-  bar
+  orig
+
+
+Test autounstashing when leaving a directory.  {{{
+
+Setup:
+
+  $ cd sub
+  ENTER
+  $ echo 'echo ENTER; autostash VAR=changed' > $AUTOENV_FILE_ENTER
+  $ echo 'echo LEAVE; echo "no explicit call to autounstash"' > $AUTOENV_FILE_LEAVE
+  $ test_autoenv_auth_env_files
+
+$VAR is empty:
+
+  $ echo VAR:$VAR
+  VAR:
+
+Set it:
+
+  $ VAR=orig
+  $ cd ..
+  LEAVE
+  no explicit call to autounstash
+
+Leaving the directory keeps it intact - nothing had been stashed yet.
+
+  $ echo $VAR
+  orig
+
+Enter the dir, trigger the autostashing.
+
+  $ cd sub
+  ENTER
+  $ echo $VAR
+  changed
+
+Now leave again.
+
+  $ cd ..
+  LEAVE
+  no explicit call to autounstash
+  $ echo $VAR
+  orig
+
+
+Remove the leave file, auto-unstashing should still happen.
+
+  $ rm sub/$AUTOENV_FILE_LEAVE
+  $ cd sub
+  ENTER
+  $ echo $VAR
+  changed
+  $ cd ..
+  $ echo $VAR
+  orig
+
+}}}


### PR DESCRIPTION
Makes sense, doesn't it?
