### PR TITLE
Fix for #14 and $AUTHENV_ENV_FILENAME not found

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -57,7 +57,7 @@ _autoenv_stack_entered_add() {
 
   # Append it to the stack, and remember its mtime.
   _autoenv_stack_entered+=($env_file)
-  _autoenv_stack_entered_mtime[$env_file]=$(_autoenv_get_file_mtime $env_file)
+  # _autoenv_stack_entered_mtime[$env_file]=$(_autoenv_get_file_mtime $env_file)
 }
 
 _autoenv_get_file_mtime() {
@@ -72,8 +72,8 @@ _autoenv_get_file_mtime() {
 _autoenv_stack_entered_remove() {
   local env_file=$1
   _autoenv_debug "[stack] removing: $env_file" 2
-  _autoenv_stack_entered[$_autoenv_stack_entered[(i)$env_file]]=()
-  _autoenv_stack_entered_mtime[$env_file]=
+  _autoenv_stack_entered[_autoenv_stack_entered[(i)$env_file]]=()
+  # _autoenv_stack_entered_mtime[$env_file]=
 }
 
 # Is the given entry already in the stack?


### PR DESCRIPTION
This pull requests fixes two issues
1. If $AUTHENV_ENV_FILENAME is not found then >> raises an error if no clobber is set in zsh
2. A very dirty fix for #14 which atleast renders it usable in my system 
