### PR TITLE
WIP: Do not `cd` in the `chpwd` hook

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -26,7 +26,7 @@ export AUTOENV_ENV_FILENAME=$HOME/.env_auth
 # Source the next .env file from parent directories.
 # This is useful if you want to use a base .env file for a directory subtree.
 autoenv_source_parent() {
-  local parent_env_file=$(_autoenv_get_file_upwards $PWD)
+  local parent_env_file=$(_autoenv_get_file_upwards ${autoenv_env_file:h})
 
   if [[ -n $parent_env_file ]] \
     && _autoenv_check_authorized_env_file $parent_env_file; then
@@ -223,13 +223,11 @@ _autoenv_source() {
 
   # Change to directory of env file, source it and cd back.
   local new_dir=$PWD
-  builtin cd -q $_autoenv_envfile_dir
   _autoenv_debug "== SOURCE: ${bold_color:-}$env_file${reset_color:-}\n      PWD: $PWD"
   (( _autoenv_debug_indent++ ))
   source $env_file
   (( _autoenv_debug_indent-- ))
   _autoenv_debug "== END SOURCE =="
-  builtin cd -q $new_dir
 
   if [[ $autoenv_event == enter ]]; then
     _autoenv_stack_entered_add $env_file

--- a/tests/cwd.t
+++ b/tests/cwd.t
@@ -7,8 +7,8 @@ Setup env actions / output.
   $ AUTOENV_LOOK_UPWARDS=1
   $ mkdir -p sub/sub2
   $ cd sub
-  $ echo 'echo ENTERED: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env
-  $ echo 'echo LEFT: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env.leave
+  $ echo 'echo ENTERED: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env
+  $ echo 'echo LEFT: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env.leave
 
 Manually create auth files.
 
@@ -17,21 +17,21 @@ Manually create auth files.
 The actual tests.
 
   $ cd .
-  ENTERED: PWD:sub from:sub to:sub event:enter
+  ENTERED: PWD:sub pwd:sub from:sub to:sub event:enter
 
   $ cd ..
-  LEFT: PWD:sub from:sub to:cwd.t event:leave
+  LEFT: PWD:cwd.t pwd:cwd.t from:sub to:cwd.t event:leave
 
   $ cd sub/sub2
-  ENTERED: PWD:sub from:cwd.t to:sub2 event:enter
+  ENTERED: PWD:sub2 pwd:sub2 from:cwd.t to:sub2 event:enter
 
 Check that symlinked dirs get handled correctly.
 
   $ cd ../..
-  LEFT: PWD:sub from:sub2 to:cwd.t event:leave
+  LEFT: PWD:cwd.t pwd:cwd.t from:sub2 to:cwd.t event:leave
   $ ln -s sub sub_linked
   $ cd sub_linked
-  ENTERED: PWD:sub from:cwd.t to:sub_linked event:enter
+  ENTERED: PWD:sub_linked pwd:sub_linked from:cwd.t to:sub_linked event:enter
   $ cd sub2
-  ENTERED: PWD:sub from:sub_linked to:sub2 event:enter
+  ENTERED: PWD:sub2 pwd:sub2 from:sub_linked to:sub2 event:enter
   $ cd .

--- a/tests/recurse-upwards.t
+++ b/tests/recurse-upwards.t
@@ -16,7 +16,7 @@ Create env files in sub dir.
 
   $ mkdir -p sub/sub2
   $ cd sub
-  ENTERED_root: PWD:recurse-upwards.t from:recurse-upwards.t to:sub
+  ENTERED_root: PWD:sub from:recurse-upwards.t to:sub
 
   $ echo 'echo ENTERED_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env
   $ echo 'echo LEFT_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env.leave
@@ -28,10 +28,10 @@ The actual tests.
   ENTERED_sub: PWD:sub from:sub to:sub
 
   $ cd ..
-  LEFT_sub: PWD:sub from:sub to:recurse-upwards.t
+  LEFT_sub: PWD:recurse-upwards.t from:sub to:recurse-upwards.t
 
   $ cd sub/sub2
-  ENTERED_sub: PWD:sub from:recurse-upwards.t to:sub2
+  ENTERED_sub: PWD:sub2 from:recurse-upwards.t to:sub2
 
   $ cd ..
 
@@ -54,7 +54,7 @@ Add sub/sub2/.env file, with a call to autoenv_source_parent.
   $ test_autoenv_add_to_env sub2/.env
   $ cd sub2
   autoenv_source_parent_from_sub2:
-  ENTERED_sub: PWD:sub from:sub to:sub2
+  ENTERED_sub: PWD:sub2 from:sub to:sub2
   ENTER2
   done_sub2
 
@@ -64,7 +64,7 @@ Move sub/.env away, now the root .env file should get sourced.
   $ touch -t 201401010102 .env
   $ cd .
   autoenv_source_parent_from_sub2:
-  ENTERED_root: PWD:recurse-upwards.t from:sub2 to:sub2
+  ENTERED_root: PWD:sub2 from:sub2 to:sub2
   done_sub2
   $ mv ../.env.out ../.env
 
@@ -78,7 +78,7 @@ Prepend call to autoenv_source_parent to sub/.env file.
 
   $ cd .
   autoenv_source_parent_from_sub:
-  ENTERED_root: PWD:recurse-upwards.t from:sub to:sub
+  ENTERED_root: PWD:sub from:sub to:sub
   ENTERED_sub: PWD:sub from:sub to:sub
   ENTER2
   done_sub
@@ -91,8 +91,8 @@ Add sub/sub2/.env file.
   $ cd sub2
   autoenv_source_parent_from_sub2:
   autoenv_source_parent_from_sub:
-  ENTERED_root: PWD:recurse-upwards.t from:sub to:sub
-  ENTERED_sub: PWD:sub from:sub to:sub
+  ENTERED_root: PWD:sub2 from:sub to:sub2
+  ENTERED_sub: PWD:sub2 from:sub to:sub2
   ENTER2
   done_sub
   done_sub2
@@ -102,7 +102,7 @@ This should not trigger the enter event, because it was handled via
 autoenv_source_parent already.
 
   $ cd ../..
-  LEFT_sub: PWD:sub from:sub2 to:recurse-upwards.t
+  LEFT_sub: PWD:recurse-upwards.t from:sub2 to:recurse-upwards.t
 
 
 Changing the root .env should trigger re-authentication via autoenv_source_parent.
@@ -155,13 +155,13 @@ Touching the .env file will now source the parent env file.
 
 
   $ cd ..
-  LEFT_sub: PWD:sub from:sub to:recurse-upwards.t
+  LEFT_sub: PWD:recurse-upwards.t from:sub to:recurse-upwards.t
   $ mkdir sub/sub2/sub3
   $ cd sub/sub2/sub3
   autoenv_source_parent_from_sub2:
   autoenv_source_parent_from_sub:
   NEW
-  ENTERED_sub: PWD:sub from:recurse-upwards.t to:sub
+  ENTERED_sub: PWD:sub3 from:recurse-upwards.t to:sub3
   ENTER2
   done_sub
   done_sub2


### PR DESCRIPTION
This messes around with `cd -` and is not really necessary.

EXPERIMENTAL: Instead, $PWD gets set for the `source` command now.
This is a bit weird, as this causes $PWD and $(pwd) to be different!

The new `$autoenv_env_file` can be used for this, as in
`${autoenv_env_file:h}` to get the directory of the .env file.

@Tarrasch 
What do you think?
Should we set `$PWD` like this (also for backward compatibility), or should only `$autoenv_env_file` be used?
See the changed tests for the implantations.