### PR TITLE
Do not reset the stack variables when (re)sourcing the plugin

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -41,10 +41,8 @@ autoenv_source_parent() {
 # Internal functions. {{{
 # Internal: stack of entered (and handled) directories. {{{
 typeset -g -a _autoenv_stack_entered
-_autoenv_stack_entered=()
 # -g: make it global, this is required when used with antigen.
 typeset -g -A _autoenv_stack_entered_mtime
-_autoenv_stack_entered_mtime=()
 
 # Add an entry to the stack, and remember its mtime.
 _autoenv_stack_entered_add() {

--- a/tests/ZDOTDIR/.zshenv
+++ b/tests/ZDOTDIR/.zshenv
@@ -2,7 +2,6 @@ test -f "$TESTDIR/.zcompdump" && rm "$TESTDIR/.zcompdump"
 
 AUTOENV_DEBUG=0
 
-source "$TESTDIR/../autoenv.plugin.zsh"
 export AUTOENV_ENV_FILENAME="$PWD/.env_auth"
 
 echo -n > $AUTOENV_ENV_FILENAME

--- a/tests/autoenv.t
+++ b/tests/autoenv.t
@@ -74,6 +74,7 @@ Now, will it take no for an answer?
 
 Lets also try one more time to ensure it didn't add it.
 
+  $ _autoenv_ask_for_yes() { echo "yes"; return 0 }
   $ cd .
   Attempting to load unauthorized env file!
   -* /tmp/cramtests-*/autoenv.t/.env (glob)
@@ -84,4 +85,11 @@ Lets also try one more time to ensure it didn't add it.
   
   **********************************************
   
-  Would you like to authorize it? (type 'yes') no
+  Would you like to authorize it? (type 'yes') yes
+  ENTERED
+
+Reloading the script should keep the current state, e.g. when reloading your
+~/.zshrc.
+
+  $ source $TEST_AUTOENV_PLUGIN_FILE
+  $ cd .

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -14,6 +14,9 @@ if [[ $AUTOENV_ENV_FILENAME[0,4] != '/tmp' ]]; then
   return 1
 fi
 
+TEST_AUTOENV_PLUGIN_FILE="$TESTDIR/../autoenv.plugin.zsh"
+source $TEST_AUTOENV_PLUGIN_FILE
+
 # Reset any authentication.
 echo -n >| $AUTOENV_ENV_FILENAME
 


### PR DESCRIPTION
This is meant to keep the current state when re-sourcing the shell
config (`. ~/.zshrc`).

I've been using `exec zsh` instead, but the above method seems to work better in general.