### PR TITLE
Change default for AUTOENV_FILE_LEAVE to .env_leave

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -9,7 +9,7 @@
 
 # Name of file to look for when leaving directories.
 # Requires AUTOENV_HANDLE_LEAVE=1.
-: ${AUTOENV_FILE_LEAVE:=.env.leave}
+: ${AUTOENV_FILE_LEAVE:=.env_leave}
 
 # Look for .env in parent dirs?
 : ${AUTOENV_LOOK_UPWARDS:=1}

--- a/tests/cwd.t
+++ b/tests/cwd.t
@@ -8,7 +8,7 @@ Setup env actions / output.
   $ mkdir -p sub/sub2
   $ cd sub
   $ echo 'echo ENTERED: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env
-  $ echo 'echo LEFT: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env.leave
+  $ echo 'echo LEFT: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env_leave
 
 Manually create auth files.
 

--- a/tests/leave.t
+++ b/tests/leave.t
@@ -5,7 +5,7 @@ Lets set a simple .env action
   $ mkdir sub
   $ cd sub
   $ echo 'echo ENTERED' > .env
-  $ echo 'echo LEFT' > .env.leave
+  $ echo 'echo LEFT' > .env_leave
 
 Change to the directory.
 
@@ -29,7 +29,7 @@ Leave the directory and answer "no".
   $ _autoenv_ask_for_yes() { echo "no"; return 1 }
   $ cd ..
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/leave.t/sub/.env.leave (glob)
+  -* /tmp/cramtests-*/leave.t/sub/.env_leave (glob)
   
   **********************************************
   
@@ -45,7 +45,7 @@ Leave the directory and answer "no".
   $ _autoenv_ask_for_yes() { echo "yes"; return 0 }
   $ cd ..
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/leave.t/sub/.env.leave (glob)
+  -* /tmp/cramtests-*/leave.t/sub/.env_leave (glob)
   
   **********************************************
   
@@ -98,7 +98,7 @@ Test that "leave" is not triggered when entering an outside dir via symlink.
   $ mkdir outside
   $ cd outside
   $ echo 'echo ENTERED outside: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env
-  $ echo 'echo LEFT outside: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env.leave
+  $ echo 'echo LEFT outside: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .env_leave
   $ test_autoenv_auth_env_files
 
   $ cd ..

--- a/tests/recurse-upwards.t
+++ b/tests/recurse-upwards.t
@@ -9,7 +9,7 @@ Setup env actions / output.
 Create env files in root dir.
 
   $ echo 'echo ENTERED_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env
-  $ echo 'echo LEFT_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env.leave
+  $ echo 'echo LEFT_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env_leave
   $ test_autoenv_auth_env_files
 
 Create env files in sub dir.
@@ -19,7 +19,7 @@ Create env files in sub dir.
   ENTERED_root: PWD:sub from:recurse-upwards.t to:sub
 
   $ echo 'echo ENTERED_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env
-  $ echo 'echo LEFT_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env.leave
+  $ echo 'echo LEFT_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .env_leave
   $ test_autoenv_auth_env_files
 
 The actual tests.


### PR DESCRIPTION
This does not use a fake file extension (`.leave`) like with `.env.leave`.