### PR TITLE
Unset global variabels

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -355,3 +355,7 @@ add-zsh-hook chpwd _autoenv_chpwd_handler
 
 # Look in current directory already.
 _autoenv_chpwd_handler
+
+# Unset global varaibles
+unset _autoenv_source_dir
+unset _autoenv_chpwd_prev_dir


### PR DESCRIPTION
_autoenv_source_dir & _autoenv_chpwd_prev_dir are globally set
and they pollute my prompt when I cd into those directories