### PR TITLE
Cleanup API/vars for enter/leave events

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -245,38 +245,28 @@ _autoenv_check_authorized_env_file() {
 }
 
 _autoenv_source() {
-  local env_file=$1
-  autoenv_event=$2
-  local _autoenv_envfile_dir=${3:-${1:A:h}}
-
-  autoenv_from_dir=$OLDPWD
-  autoenv_to_dir=$PWD
-  autoenv_env_file=$env_file
+  # Public API for the .autoenv.zsh script.
+  local autoenv_env_file=$1
+  local autoenv_event=$2
+  local autoenv_from_dir=$OLDPWD
+  local autoenv_to_dir=$PWD
 
   # Source varstash library once.
   if [[ -z "$functions[(I)autostash]" ]]; then
     source ${${funcsourcetrace[1]%:*}:h}/lib/varstash
     # NOTE: Varstash uses $PWD as default for varstash_dir, we might set it to
-    # ${env_file:h}.
+    # ${autoenv_env_file:h}.
   fi
 
   # Source the env file.
-  _autoenv_debug "== SOURCE: ${bold_color:-}$env_file${reset_color:-}\n      PWD: $PWD"
+  _autoenv_debug "== SOURCE: ${bold_color:-}$autoenv_env_file${reset_color:-}\n      PWD: $PWD"
   : $(( _autoenv_debug_indent++ ))
-  source $env_file
+  source $autoenv_env_file
   : $(( _autoenv_debug_indent-- ))
   _autoenv_debug "== END SOURCE =="
 
   if [[ $autoenv_event == enter ]]; then
-    _autoenv_stack_entered_add $env_file
-  fi
-
-  # Unset vars set for enter/leave scripts.
-  # This should not get done for recursion (via autoenv_source_parent),
-  # and can be useful to have in general after autoenv was used.
-  # unset autoenv_event autoenv_from_dir autoenv_to_dir autoenv_env_file
-  if [[ $autoenv_event == leave ]]; then
-    unset autoenv_env_file
+    _autoenv_stack_entered_add $autoenv_env_file
   fi
 }
 

--- a/tests/leave.t
+++ b/tests/leave.t
@@ -99,6 +99,7 @@ Test that "leave" is not triggered when entering an outside dir via symlink.
   $ cd outside
   $ echo 'echo ENTERED outside: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .autoenv.zsh
   $ echo 'echo LEFT outside: PWD:${PWD:t} pwd:${${"$(pwd)"}:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t} event:${autoenv_event}' > .autoenv_leave.zsh
+  $ echo 'echo LEFT: autoenv_env_file:${autoenv_env_file}' >> .autoenv_leave.zsh
   $ test_autoenv_auth_env_files
 
   $ cd ..
@@ -111,14 +112,19 @@ Test that "leave" is not triggered when entering an outside dir via symlink.
   $ cd ../..
   LEFT
   LEFT outside: PWD:leave.t pwd:leave.t from:symlink to:leave.t event:leave
+  LEFT: autoenv_env_file:*/leave.t/sub/symlink/.autoenv_leave.zsh (glob)
   $ cd sub/symlink
   ENTERED outside: PWD:symlink pwd:symlink from:leave.t to:symlink event:enter
 
+$autoenv_env_file should not be exported.
+
+  $ echo -n $autoenv_env_file
+
 $autoenv_env_file should be reset when leaving.
 
-  $ echo $autoenv_env_file
-  */leave.t/sub/symlink/.autoenv.zsh (glob)
+  $ echo -n $autoenv_env_file
   $ cd ../..
   LEFT outside: PWD:leave.t pwd:leave.t from:symlink to:leave.t event:leave
+  LEFT: autoenv_env_file:*/leave.t/sub/symlink/.autoenv_leave.zsh (glob)
   $ echo ${autoenv_env_file:-empty}
   empty

--- a/tests/setup.zsh
+++ b/tests/setup.zsh
@@ -33,8 +33,9 @@ test_autoenv_add_to_env() {
 
 # Add enter and leave env files to authentication file.
 test_autoenv_auth_env_files() {
-  test_autoenv_add_to_env $PWD/$AUTOENV_FILE_ENTER
-  test_autoenv_add_to_env $PWD/$AUTOENV_FILE_LEAVE
+  local dir=${1:-$PWD}
+  test_autoenv_add_to_env $dir/$AUTOENV_FILE_ENTER
+  test_autoenv_add_to_env $dir/$AUTOENV_FILE_LEAVE
 }
 
 # Now keep on going on errors again.

--- a/tests/source-parent-vars.t
+++ b/tests/source-parent-vars.t
@@ -1,0 +1,38 @@
+Test vars with autoenv_source_parent.
+
+  $ source $TESTDIR/setup.zsh || return 1
+
+Setup env actions / output.
+
+  $ AUTOENV_LOOK_UPWARDS=1
+
+Create env files in root dir.
+
+  $ echo 'echo ENTERED_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv.zsh
+  $ echo 'echo LEFT_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv_leave.zsh
+  $ test_autoenv_auth_env_files
+
+Create env files in sub dir.
+
+  $ mkdir -p sub/sub2
+  $ echo 'echo ENTERED_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > sub/.autoenv.zsh
+  $ echo 'echo LEFT_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > sub/.autoenv_leave.zsh
+  $ test_autoenv_auth_env_files sub
+
+  $ echo 'echo ENTERED_sub2: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > sub/sub2/.autoenv.zsh
+  $ echo 'echo LEFT_sub2: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > sub/sub2/.autoenv_leave.zsh
+  $ echo 'echo autoenv_source_parent_from_sub2\n' >> sub/sub2/.autoenv.zsh
+  $ echo 'echo autoenv_env_file_1:${autoenv_env_file:h:t}\nautoenv_source_parent\n' >> sub/sub2/.autoenv.zsh
+  $ echo 'echo autoenv_env_file_2:${autoenv_env_file:h:t}\necho done_sub3\n' >> sub/sub2/.autoenv.zsh
+  $ test_autoenv_auth_env_files sub/sub2
+
+The actual tests.
+
+  $ cd sub/sub2
+  ENTERED_sub2: PWD:sub2 from:source-parent-vars.t to:sub2
+  autoenv_source_parent_from_sub2
+  autoenv_env_file_1:sub2
+  ENTERED_sub: PWD:sub2 from:source-parent-vars.t to:sub2
+  autoenv_env_file_2:sub2
+  done_sub3
+


### PR DESCRIPTION
The variables are local now, which makes them being handled correctly
when calling `autoenv_source_parent`.
Without this, a call to `autoenv_source_parent` overwrites the values in
the current scope.