### PR TITLE
Allow to limit `autoenv_source_parent`'s upward recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ The varstash library has been taken from smartcd, and was optimized for Zsh.
 
 ### `autoenv_source_parent()`
 
-zsh-autoenv will stop looking for `.autoenv.zsh` files after the first one has
-been found.  But you can use the function `autoenv_source_parent` to source a
-parent `.autoenv.zsh` file from there.
+zsh-autoenv will stop looking for `.autoenv.zsh` files upwards after the first
+one has been found, but you can use the function `autoenv_source_parent` to
+source the next `.autoenv.zsh` file upwards the directory tree from there.
 
+The function accepts an optional argument, which allows to stop looking before
+the file system root is reached:
+
+```zsh
+autoenv_source_parent ../..
+```
 
 ## Installation
 

--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -48,7 +48,9 @@ fi
 # This is useful if you want to use a base .autoenv.zsh file for a directory
 # subtree.
 autoenv_source_parent() {
-  local parent_env_file=$(_autoenv_get_file_upwards ${autoenv_env_file:h})
+  local look_until=${1:-/}
+  local parent_env_file=$(_autoenv_get_file_upwards \
+    ${autoenv_env_file:h} ${AUTOENV_FILE_ENTER} $look_until)
 
   if [[ -n $parent_env_file ]] \
     && _autoenv_check_authorized_env_file $parent_env_file; then
@@ -283,6 +285,7 @@ _autoenv_source() {
 _autoenv_get_file_upwards() {
   local look_from=${1:-$PWD}
   local look_for=${2:-$AUTOENV_FILE_ENTER}
+  local look_until=${${3:-/}:A}
 
   # Manually look in parent dirs. An extended Zsh glob should use Y1 for
   # performance reasons, which is only available in zsh-5.0.5-146-g9381bb6.
@@ -300,6 +303,9 @@ _autoenv_get_file_upwards() {
       break
     fi
 
+    if [[ $parent_dir == $look_until ]]; then
+      break
+    fi
     last=$parent_dir
     parent_dir="${parent_dir}/.."
   done

--- a/tests/source-parent-until.t
+++ b/tests/source-parent-until.t
@@ -1,0 +1,92 @@
+Test recursing into parent .autoenv.zsh files.
+
+  $ source $TESTDIR/setup.zsh || return 1
+
+Setup env actions / output.
+
+  $ AUTOENV_LOOK_UPWARDS=1
+
+Create env files in root dir.
+
+  $ echo 'echo ENTERED_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv.zsh
+  $ echo 'echo LEFT_root: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv_leave.zsh
+  $ test_autoenv_auth_env_files
+
+Create env files in sub dir.
+
+  $ mkdir -p sub/sub2/sub3/sub4
+  $ cd sub
+  ENTERED_root: PWD:sub from:source-parent-until.t to:sub
+
+  $ echo 'echo ENTERED_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv.zsh
+  $ echo 'echo LEFT_sub: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv_leave.zsh
+  $ test_autoenv_auth_env_files
+
+  $ cd sub2
+  ENTERED_sub: PWD:sub2 from:sub to:sub2
+  $ echo 'echo ENTERED_sub2: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv.zsh
+  $ echo 'echo LEFT_sub2: PWD:${PWD:t} from:${autoenv_from_dir:t} to:${autoenv_to_dir:t}' > .autoenv_leave.zsh
+  $ test_autoenv_auth_env_files
+
+The actual tests.
+
+# $ cd sub3
+# ENTERED_sub2: PWD:sub3 from:sub2 to:sub3
+# $ cd ../..
+# LEFT_sub2: PWD:sub from:sub3 to:sub
+  $ cd ..
+
+Add sub/sub2/sub3/.autoenv.zsh file, with a call to autoenv_source_parent,
+stopping at the parent dir.
+
+  $ echo "echo autoenv_source_parent_from_sub3:\nautoenv_source_parent ..\necho done_sub3\n" > sub2/sub3/.autoenv.zsh
+  $ test_autoenv_add_to_env sub2/sub3/.autoenv.zsh
+  $ cd sub2/sub3
+  autoenv_source_parent_from_sub3:
+  ENTERED_sub2: PWD:sub3 from:sub to:sub3
+  done_sub3
+
+Look up to `../..` now.
+
+  $ cd ../..
+  LEFT_sub2: PWD:sub from:sub3 to:sub
+  $ echo "echo autoenv_source_parent_from_sub3:\nautoenv_source_parent ../..\necho done_sub3\n" >| sub2/sub3/.autoenv.zsh
+  $ test_autoenv_add_to_env sub2/sub3/.autoenv.zsh
+  $ cd sub2/sub3
+  autoenv_source_parent_from_sub3:
+  ENTERED_sub2: PWD:sub3 from:sub to:sub3
+  done_sub3
+
+Remove intermediate .autoenv.zsh from sub2.
+
+  $ cd ../..
+  LEFT_sub2: PWD:sub from:sub3 to:sub
+  $ rm sub2/.autoenv.zsh
+
+Should source "sub" for ../.. now.
+
+  $ echo "echo autoenv_source_parent_from_sub3:\nautoenv_source_parent ../..\necho done_sub3\n" >| sub2/sub3/.autoenv.zsh
+  $ test_autoenv_add_to_env sub2/sub3/.autoenv.zsh
+  $ cd sub2/sub3
+  autoenv_source_parent_from_sub3:
+  ENTERED_sub: PWD:sub3 from:sub to:sub3
+  done_sub3
+
+Should source nothing for .. now.
+
+  $ cd ../..
+  $ echo "echo autoenv_source_parent_from_sub3:\nautoenv_source_parent ..\necho done_sub3\n" >| sub2/sub3/.autoenv.zsh
+  $ test_autoenv_add_to_env sub2/sub3/.autoenv.zsh
+  $ cd sub2/sub3
+  autoenv_source_parent_from_sub3:
+  done_sub3
+
+Look up to "/" (default).
+
+  $ cd ../..
+  $ echo "echo autoenv_source_parent_from_sub3:\nautoenv_source_parent /\necho done_sub3\n" >| sub2/sub3/.autoenv.zsh
+  $ test_autoenv_add_to_env sub2/sub3/.autoenv.zsh
+  $ cd sub2/sub3
+  autoenv_source_parent_from_sub3:
+  ENTERED_sub: PWD:sub3 from:sub to:sub3
+  done_sub3


### PR DESCRIPTION
This allows to use `autoenv_source_parent ..` to only look in the parent
directory.