### PR TITLE
Create path to non-existing auth file

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -194,6 +194,7 @@ _autoenv_authorized_env_file() {
 _autoenv_authorize() {
   local env_file=${1:A}
   _autoenv_deauthorize $env_file
+  [[ -d ${AUTOENV_AUTH_FILE:h} ]] || mkdir -p ${AUTOENV_AUTH_FILE:h}
   _autoenv_hash_pair $env_file >>| $AUTOENV_AUTH_FILE
 }
 

--- a/tests/_autoenv_utils.t
+++ b/tests/_autoenv_utils.t
@@ -21,7 +21,7 @@ Tests for _autoenv_authorize. {{{
 Auth file is empty.
 
   $ cd ../..
-  $ cat $AUTOENV_AUTH_FILE
+  $ ! [[ -f "$AUTOENV_AUTH_FILE" ]] || cat $AUTOENV_AUTH_FILE
 
 Failed authorization should keep the auth file empty.
 

--- a/tests/setup.zsh
+++ b/tests/setup.zsh
@@ -9,7 +9,7 @@
 # Not handled in varstash yet.
 # setopt nounset
 
-export AUTOENV_AUTH_FILE="$CRAMTMP/.autoenv_auth"
+export AUTOENV_AUTH_FILE="$CRAMTMP/autoenv/.autoenv_auth"
 
 if [[ $AUTOENV_AUTH_FILE[0,4] != '/tmp' ]]; then
   echo "AUTOENV_AUTH_FILE is not in /tmp. Aborting."
@@ -24,7 +24,9 @@ set -e
 $TEST_SOURCE_AUTOENV
 
 # Reset any authentication.
-echo -n >| $AUTOENV_AUTH_FILE
+if [[ -f $AUTOENV_AUTH_FILE ]]; then
+  echo -n >| $AUTOENV_AUTH_FILE
+fi
 
 # Add file $1 (with optional hash $2) to authentication file.
 test_autoenv_add_to_env() {


### PR DESCRIPTION
This changes the tests to have the auth file in a non-existing subdir
always, as with `$HOME/.local/share` not being there already.

Fixes https://github.com/Tarrasch/zsh-autoenv/issues/48.