### PR TITLE
Use cksum instead of sha1sum for checksums

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -173,15 +173,15 @@ _autoenv_debug() {
 # The format is ":$file:$hash:$version".
 _autoenv_hash_pair() {
   local env_file=${1:A}
-  local env_shasum=${2:-}
-  if [[ -z $env_shasum ]]; then
+  local env_cksum=${2:-}
+  if [[ -z $env_cksum ]]; then
     if ! [[ -e $env_file ]]; then
       echo "Missing file argument for _autoenv_hash_pair!" >&2
       return 1
     fi
-    env_shasum=$(sha1sum $env_file | cut -d' ' -f1)
+    env_cksum=${(j:.:)${:-$(cksum "$env_file")}[1,2]}
   fi
-  echo ":${env_file}:${env_shasum}:1"
+  echo ":${env_file}:${env_cksum}:1"
 }
 
 _autoenv_authorized_env_file() {

--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -179,6 +179,7 @@ _autoenv_hash_pair() {
       echo "Missing file argument for _autoenv_hash_pair!" >&2
       return 1
     fi
+    # Get the output from `cksum` and join the first two words with a dot.
     env_cksum=${(j:.:)${:-$(cksum "$env_file")}[1,2]}
   fi
   echo ":${env_file}:${env_cksum}:1"

--- a/tests/_autoenv_utils.t
+++ b/tests/_autoenv_utils.t
@@ -35,41 +35,41 @@ Now adding some auth pair.
   $ echo first > first
   $ _autoenv_authorize first
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:271ac93c44ac198d92e706c6d6f1d84aefcfa337:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:1 (glob)
 
 And a second one.
 
   $ echo second > second
   $ _autoenv_authorize second
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:271ac93c44ac198d92e706c6d6f1d84aefcfa337:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:7bee8f3b184e1e141ff76efe369c3b8bfc50e64c:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:1 (glob)
 
 And a third.
 
   $ echo third > third
   $ _autoenv_authorize third
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:271ac93c44ac198d92e706c6d6f1d84aefcfa337:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:7bee8f3b184e1e141ff76efe369c3b8bfc50e64c:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/third:ad180453bf8a374a15df3e90a78c180230146a7c:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:1 (glob)
 
 Re-add the second one, with the same hash.
 
   $ _autoenv_authorize second
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:271ac93c44ac198d92e706c6d6f1d84aefcfa337:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/third:ad180453bf8a374a15df3e90a78c180230146a7c:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:7bee8f3b184e1e141ff76efe369c3b8bfc50e64c:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:1 (glob)
 
 Re-add the first one, with a new hash.
 
   $ echo one more line >> first
   $ _autoenv_authorize first
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/third:ad180453bf8a374a15df3e90a78c180230146a7c:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:7bee8f3b184e1e141ff76efe369c3b8bfc50e64c:1 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/first:65eb010197b73ddc109b7210080f97a87f53451e:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:1 (glob)
+  :/tmp/cramtests-*/_autoenv_utils.t/first:3620404822.20:1 (glob)
 }}}
 
 


### PR DESCRIPTION
Fixes https://github.com/Tarrasch/zsh-autoenv/issues/53.

We might to migrate existing checksums?!
Not sure if it's worth the effort though..