### PR TITLE
Modifies 	`_autoenv_get_file_upwards` to not dereference symlinks.

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -342,7 +342,7 @@ _autoenv_get_file_upwards() {
       if [[ ${parent_file[1,2]} == './' ]]; then
         echo ${parent_file#./}
       else
-        echo ${parent_file:A}
+        echo ${parent_file:a}
       fi
       break
     fi

--- a/tests/_autoenv_utils.t
+++ b/tests/_autoenv_utils.t
@@ -17,6 +17,15 @@ Should not get the file from the current dir.
   $ _autoenv_get_file_upwards $PWD file
   */_autoenv_utils.t/sub/file (glob)
 
+_autoenv_get_file_upwards should not dereference symlinks.
+
+  $ cd ../..
+  $ ln -s sub symlink
+  $ cd symlink/sub2
+  $ _autoenv_get_file_upwards . file
+  ../file
+  $ _autoenv_get_file_upwards $PWD file
+  */_autoenv_utils.t/symlink/file (glob)
 
 Tests for _autoenv_authorize. {{{
 


### PR DESCRIPTION
This prevents issues where symlinked autoenv scripts use $0. When a shell enters the directory holding the autoenv scripts, it works as expected with $0 being the path to the symlink. However, if the shell enters one of its child directories the path to the script is dereferenced, and $0 is instead the path to the symlink's target.

The fix is quite simple. From `man 1 zshexpn`:

> A – Turn a file name into an absolute path as the 'a' modifier does, and then pass  the  result  through  the  realpath(3) library function to resolve symbolic links.

So I just replaced :A with :a.

Note: Symlinks are dereferenced elsewhere for authorization, so that behavior is unchanged.