### PR TITLE
Fix tests: match $CRAMTMP more losely

### DIFF
--- a/tests/_autoenv_utils.t
+++ b/tests/_autoenv_utils.t
@@ -46,41 +46,41 @@ Now adding some auth pair.
   $ echo first > first
   $ _autoenv_authorize first
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
 
 And a second one.
 
   $ echo second > second
   $ _autoenv_authorize second
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
 
 And a third.
 
   $ echo third > third
   $ _autoenv_authorize third
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
 
 Re-add the second one, with the same hash.
 
   $ _autoenv_authorize second
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/first:2715464726.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
 
 Re-add the first one, with a new hash.
 
   $ echo one more line >> first
   $ _autoenv_authorize first
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
-  :/tmp/cramtests-*/_autoenv_utils.t/first:3620404822.20:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/third:451243482.6:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/second:594940475.7:2 (glob)
+  :/*/cramtests-*/_autoenv_utils.t/first:3620404822.20:2 (glob)
 }}}
 
 

--- a/tests/autoenv.t
+++ b/tests/autoenv.t
@@ -17,7 +17,7 @@ Now try to make it accept it
   $ _autoenv_ask_for_yes() { echo "yes" }
   $ cd .
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/autoenv.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/autoenv.t/.autoenv.zsh (glob)
   
   **********************************************
   
@@ -42,7 +42,7 @@ Now lets see that it actually checks the shasum value.
   $ test_autoenv_add_to_env $PWD/.autoenv.zsh mischief
   $ cd .
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/autoenv.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/autoenv.t/.autoenv.zsh (glob)
   
   **********************************************
   
@@ -61,7 +61,7 @@ Now, will it take no for an answer?
   $ _autoenv_ask_for_yes() { echo "no"; return 1 }
   $ cd .
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/autoenv.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/autoenv.t/.autoenv.zsh (glob)
   
   **********************************************
   
@@ -77,7 +77,7 @@ Lets also try one more time to ensure it didn't add it.
   $ _autoenv_ask_for_yes() { echo "yes"; return 0 }
   $ cd .
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/autoenv.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/autoenv.t/.autoenv.zsh (glob)
   
   **********************************************
   

--- a/tests/leave.t
+++ b/tests/leave.t
@@ -12,7 +12,7 @@ Change to the directory.
   $ _autoenv_ask_for_yes() { echo "yes"; return 0 }
   $ cd .
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/leave.t/sub/.autoenv.zsh (glob)
+  -* /*/cramtests-*/leave.t/sub/.autoenv.zsh (glob)
   
   **********************************************
   
@@ -29,7 +29,7 @@ Leave the directory and answer "no".
   $ _autoenv_ask_for_yes() { echo "no"; return 1 }
   $ cd ..
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/leave.t/sub/.autoenv_leave.zsh (glob)
+  -* /*/cramtests-*/leave.t/sub/.autoenv_leave.zsh (glob)
   
   **********************************************
   
@@ -45,7 +45,7 @@ Leave the directory and answer "no".
   $ _autoenv_ask_for_yes() { echo "yes"; return 0 }
   $ cd ..
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/leave.t/sub/.autoenv_leave.zsh (glob)
+  -* /*/cramtests-*/leave.t/sub/.autoenv_leave.zsh (glob)
   
   **********************************************
   

--- a/tests/recurse-upwards.t
+++ b/tests/recurse-upwards.t
@@ -115,7 +115,7 @@ First, let's answer "no".
   $ cd sub
   autoenv_source_parent_from_sub:
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/recurse-upwards.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/recurse-upwards.t/.autoenv.zsh (glob)
   
   **********************************************
   
@@ -140,7 +140,7 @@ Touching the .autoenv.zsh file will now source the parent env file.
   $ cd .
   autoenv_source_parent_from_sub:
   Attempting to load unauthorized env file!
-  -* /tmp/cramtests-*/recurse-upwards.t/.autoenv.zsh (glob)
+  -* /*/cramtests-*/recurse-upwards.t/.autoenv.zsh (glob)
   
   **********************************************
   

--- a/tests/setup.zsh
+++ b/tests/setup.zsh
@@ -11,11 +11,6 @@
 
 export AUTOENV_AUTH_FILE="$CRAMTMP/autoenv/.autoenv_auth"
 
-if [[ $AUTOENV_AUTH_FILE[0,4] != '/tmp' ]]; then
-  echo "AUTOENV_AUTH_FILE is not in /tmp. Aborting."
-  return 1
-fi
-
 # Abort this setup script on any error.
 _save_errexit=${options[errexit]}
 set -e

--- a/tests/upgrade_hash.t
+++ b/tests/upgrade_hash.t
@@ -19,7 +19,7 @@ This also tests that there are no empty lines being added to the auth file when
 de-authenticating the old hash.
 
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:3679467995.13:2 (glob)
+  :/*/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:3679467995.13:2 (glob)
 
 Re-create auth file with v1 hashes for both auth files.
 
@@ -31,13 +31,13 @@ Only the leave file's hash should get updated.
   $ cd ..
   LEAVE
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:4c403f1870af2ab5472370a42b6b2b488cefe83c:1 (glob)
-  :/tmp/cramtests-*/upgrade_hash.t/sub/.autoenv_leave.zsh:803077150.11:2 (glob)
+  :/*/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:4c403f1870af2ab5472370a42b6b2b488cefe83c:1 (glob)
+  :/*/cramtests-*/upgrade_hash.t/sub/.autoenv_leave.zsh:803077150.11:2 (glob)
 
 The enter file's hash should get updated.
 
   $ cd sub
   ENTERED
   $ cat $AUTOENV_AUTH_FILE
-  :/tmp/cramtests-*/upgrade_hash.t/sub/.autoenv_leave.zsh:803077150.11:2 (glob)
-  :/tmp/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:3679467995.13:2 (glob)
+  :/*/cramtests-*/upgrade_hash.t/sub/.autoenv_leave.zsh:803077150.11:2 (glob)
+  :/*/cramtests-*/upgrade_hash.t/sub/.autoenv.zsh:3679467995.13:2 (glob)


### PR DESCRIPTION
Fixes https://github.com/Tarrasch/zsh-autoenv/issues/76.