### PR TITLE
tests: mv ZDOTDIR.{clobber,options}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: generic
 sudo: false
 env:
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.clobber
+  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.options
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.clobber
+  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.options
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 

--- a/tests/ZDOTDIR.options/.zshenv
+++ b/tests/ZDOTDIR.options/.zshenv
@@ -1,4 +1,6 @@
 # Source base setup.
 source ${ZDOTDIR}/../ZDOTDIR/.zshenv
 
+# Set uncommon options that caused problems in the past.
 setopt noclobber
+setopt shwordsplit


### PR DESCRIPTION
Add `shwordsplit` option.

Ref: https://github.com/Tarrasch/zsh-autoenv/issues/75