### PR TITLE
tests: simplify ZDOTDIR setup, remove base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,12 @@ language: generic
 sudo: false
 env:
   - ZSH=4
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.options
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.loadviafunction
-
   - ZSH=5
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.options
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 
 install:
   - if [ "$ZSH" = 4 ]; then sudo apt-get install zsh; fi
   - if [ "$ZSH" = 5 ]; then wget http://downloads.sourceforge.net/project/zsh/zsh/5.0.7/zsh-5.0.7.tar.bz2; tar xf zsh-5.0.7.tar.bz2; cd zsh-5.0.7; ./configure && sudo make && sudo make install; cd ..; fi
   - pip install --user cram
-  - export SHELL=zsh
 script:
   - zsh --version
-  - make test ZDOTDIR=$ZDOTDIR
+  - make test_full

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: generic
 sudo: false
 env:
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR
+  - ZSH=4
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.clobber
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR
+  - ZSH=5
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.clobber
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.loadviafunction

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: generic
 sudo: false
 env:
   - ZSH=4
-  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.clobber
+  - ZSH=4 ZDOTDIR=tests/ZDOTDIR.options
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=4 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 
   - ZSH=5
-  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.clobber
+  - ZSH=5 ZDOTDIR=tests/ZDOTDIR.options
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.invalid-module_path
   - ZSH=5 ZDOTDIR=tests/ZDOTDIR.loadviafunction
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Default, can be overridden using "make test ZDOTDIR=...".
-ZDOTDIR:=${CURDIR}/tests/ZDOTDIR
+# Empty by default, can be overridden using "make test ZDOTDIR=…".
+ZDOTDIR:=
 # Make it absolute.
 override ZDOTDIR:=$(abspath $(ZDOTDIR))
 

--- a/tests/ZDOTDIR.clobber/.zshenv
+++ b/tests/ZDOTDIR.clobber/.zshenv
@@ -1,1 +1,0 @@
-setopt noclobber

--- a/tests/ZDOTDIR.clobber/.zshenv
+++ b/tests/ZDOTDIR.clobber/.zshenv
@@ -1,4 +1,1 @@
-# Source base setup.
-source ${ZDOTDIR}/../ZDOTDIR/.zshenv
-
 setopt noclobber

--- a/tests/ZDOTDIR.invalid-module_path/.zshenv
+++ b/tests/ZDOTDIR.invalid-module_path/.zshenv
@@ -9,6 +9,3 @@ module_path=(/dev/null)
 zstat() {
   echo "Should not get called."
 }
-
-# Source base setup.
-source ${ZDOTDIR}/../ZDOTDIR/.zshenv

--- a/tests/ZDOTDIR.loadviafunction/.zshenv
+++ b/tests/ZDOTDIR.loadviafunction/.zshenv
@@ -1,6 +1,3 @@
-# Source base setup.
-source ${ZDOTDIR}/../ZDOTDIR/.zshenv
-
 antigen-like-loader-function() {
   source "$TESTDIR/../autoenv.plugin.zsh"
 }

--- a/tests/ZDOTDIR.options/.zshenv
+++ b/tests/ZDOTDIR.options/.zshenv
@@ -1,0 +1,2 @@
+# Set uncommon options that caused problems in the past.
+setopt noclobber

--- a/tests/ZDOTDIR.shwordsplit/.zshenv
+++ b/tests/ZDOTDIR.shwordsplit/.zshenv
@@ -1,4 +1,0 @@
-# Source base setup.
-source ${ZDOTDIR}/../ZDOTDIR/.zshenv
-
-setopt shwordsplit

--- a/tests/ZDOTDIR/.zshenv
+++ b/tests/ZDOTDIR/.zshenv
@@ -1,3 +1,0 @@
-# Base setup/config.
-
-TEST_SOURCE_AUTOENV=(source $TESTDIR/../autoenv.plugin.zsh)

--- a/tests/setup.zsh
+++ b/tests/setup.zsh
@@ -15,7 +15,10 @@ export AUTOENV_AUTH_FILE="$CRAMTMP/autoenv/.autoenv_auth"
 _save_errexit=${options[errexit]}
 set -e
 
-# Defined in .zshenv, e.g. tests/ZDOTDIR/.zshenv.
+# Can be defined in .zshenv, e.g. tests/ZDOTDIR.loadviafunction/.zshenv.
+if [[ -z $TEST_SOURCE_AUTOENV ]]; then
+  TEST_SOURCE_AUTOENV=(source $TESTDIR/../autoenv.plugin.zsh)
+fi
 $TEST_SOURCE_AUTOENV
 
 # Reset any authentication.


### PR DESCRIPTION
This makes it easier to run tests without providing ZDOTDIR.