### PR TITLE
tests: cleanup test_full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,11 @@ itest:
 
 # Run tests with all ZDOTDIRs.
 test_full:
-	for zsh in zsh /opt/zsh-4.3.9/bin/zsh; do \
-		command -v $$zsh || { echo "Skipping non-existing shell: $$zsh"; continue; }; \
-		ret=0; \
-		for i in $(wildcard tests/ZDOTDIR*); do \
-			echo "zsh=$zsh ZDOTDIR=$$i"; \
-			SHELL=$$zsh ZDOTDIR=${CURDIR}/$$i cram --shell=$$zsh -v tests || ret=$$?; \
-			echo; \
-		done; \
+	@ret=0; \
+	for i in $(wildcard tests/ZDOTDIR*); do \
+	  echo "TEST_SHELL=$(TEST_SHELL) ZDOTDIR=$$i"; \
+	  ZDOTDIR=${CURDIR}/$$i cram --shell=$(TEST_SHELL) -v tests || ret=$$?; \
+	  echo; \
 	done; \
 	exit $$ret
 

--- a/tests/varstash_export.t
+++ b/tests/varstash_export.t
@@ -29,20 +29,20 @@ Activating the env stashes it and applies a new value.
 
 The variable is not available in a subshell, only the exported one.
 
-  $ $SHELL -c 'echo ${MYVAR:-empty}; echo $MYEXPORT'
+  $ $TESTSHELL -c 'echo ${MYVAR:-empty}; echo $MYEXPORT'
   empty
   changed_export
 
 Activate autoenv in the subshell.
 
-  $ $SHELL -c "$TEST_SOURCE_AUTOENV; echo \${MYVAR}; echo \$MYEXPORT"
+  $ $TESTSHELL -c "$TEST_SOURCE_AUTOENV; echo \${MYVAR}; echo \$MYEXPORT"
   ENTER
   changed
   changed_export
 
 "autounstash" should handle the exported variables.
 
-  $ $SHELL -c "$TEST_SOURCE_AUTOENV; cd ..; echo \${MYVAR:-empty}; echo \$MYEXPORT"
+  $ $TESTSHELL -c "$TEST_SOURCE_AUTOENV; cd ..; echo \${MYVAR:-empty}; echo \$MYEXPORT"
   ENTER
   LEAVE
   empty


### PR DESCRIPTION
Changes tests/varstash_export.t to use `$TESTSHELL` provided by cram.