### PR TITLE
Handle `setopt shwordsplit`

### DIFF
--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -350,12 +350,13 @@ _autoenv_get_file_upwards() {
     if [[ $abs_parent_dir == $look_until ]]; then
       break
     fi
-    last=$parent_dir
+    last=$abs_parent_dir
     parent_dir="${parent_dir}/.."
   done
 }
 
 autoenv-edit() {
+  emulate -L zsh
   local env_file
   local -a files
   local -A check
@@ -388,6 +389,7 @@ autoenv-edit() {
 }
 
 _autoenv_chpwd_handler() {
+  emulate -L zsh
   _autoenv_debug "Calling chpwd handler: PWD=$PWD"
 
   if (( $AUTOENV_DISABLED )); then

--- a/tests/ZDOTDIR.options/.zshenv
+++ b/tests/ZDOTDIR.options/.zshenv
@@ -1,2 +1,3 @@
 # Set uncommon options that caused problems in the past.
 setopt noclobber
+setopt shwordsplit

--- a/tests/_autoenv_utils.t
+++ b/tests/_autoenv_utils.t
@@ -96,3 +96,7 @@ of _autoenv_get_file_mtime (via ZDOTDIR.invalid-module_path/).
   $ touch -t 201401010102 dir
   $ _autoenv_get_file_mtime dir
   1388538120
+
+Stops when last (absolute) path does not change anymore.
+
+  $ _autoenv_get_file_upwards / doesnotexist nevermatches

--- a/tests/setup.zsh
+++ b/tests/setup.zsh
@@ -28,6 +28,7 @@ fi
 
 # Add file ($1), version ($2), and optional hash ($3) to authentication file.
 test_autoenv_add_to_env() {
+  emulate -L zsh
   [[ -d ${AUTOENV_AUTH_FILE:h} ]] || mkdir -p ${AUTOENV_AUTH_FILE:h}
   {
     local ret_pair

--- a/tests/source-parent-until.t
+++ b/tests/source-parent-until.t
@@ -90,3 +90,19 @@ Look up to "/" (default).
   autoenv_source_parent_from_sub3:
   ENTERED_sub: PWD:sub3 from:sub to:sub3
   done_sub3
+
+Handles dirs with spaces.
+
+  $ mkdir "dir with space"
+  $ echo "echo entered \$PWD\n" >| "dir with space/.autoenv.zsh"
+  $ test_autoenv_add_to_env "dir with space/.autoenv.zsh"
+  $ cd "dir with space"
+  entered */dir with space (glob)
+
+Handles dirs with spaces outside any root (should not hang).
+
+  $ cd $CRAMTMP || exit
+  LEFT_root: * (glob)
+  LEFT_sub: * (glob)
+  $ mkdir "dir with space"
+  $ cd "dir with space"


### PR DESCRIPTION
This uses `emulate -L zsh` (as a more broad approach to `setopt
localtoptions noshwordsplit`, or quoting things) in the entry points to
zsh-autoenv.

Fixes https://github.com/Tarrasch/zsh-autoenv/issues/75