### PR TITLE
minor patches to make it work with zsh 5.0.2 as delivered in CentOS 7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ if [[ $autoenv_event == 'enter' ]]; then
 
     setopt localoptions extendedglob
     local -a venv
-    venv=(./(../)#.venv(NY1:A))
+    venv=(./(../)#.venv(N:A))
+    venv=( ${venv[1]} )
+    venv=( ${venv:#} )
 
     if [[ -n "$_ZSH_ACTIVATED_VIRTUALENV" && -n "$VIRTUAL_ENV" ]]; then
       if ! (( $#venv )) || [[ "$_ZSH_ACTIVATED_VIRTUALENV" != "$venv[1]" ]]; then

--- a/autoenv.zsh
+++ b/autoenv.zsh
@@ -75,7 +75,8 @@ autoenv_prepend_path() {
 }
 autoenv_remove_path() {
   local i
-  local old_path=$path
+  local old_path
+  old_path=$path
   for i; do
     path=("${(@)path:#$i}")
   done


### PR DESCRIPTION
I hit two problems trying to use zsh-autoenv with ZSH 5.0.2 as delivered in CentOS 7.9.

This patch fixes/removes those problems and allows the software to work cleanly.

Jeff.