### PR TITLE
Fix stashing aliases with a space in double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,22 @@ features, mainly inspired by [smartcd].
 
 [antigen]: https://github.com/Tarrasch/antigen-hs
 [smartcd]: https://github.com/cxreg/smartcd
+
+## Contributing
+
+Bug reports, contributions and forks are welcome. All bugs or other forms of
+discussion happen on https://github.com/Tarrasch/zsh-autoenv/issues.
+
+### Testing
+
+To run our tests you need to have `cram` installed. You can do this by running:
+
+```bash
+% pip install cram
+```
+
+Then you can run the tests by running:
+```bash
+% make test_full # Run all tests
+% make test tests/varstash-alias.t # Run a single test
+```

--- a/lib/varstash
+++ b/lib/varstash
@@ -108,6 +108,7 @@ function stash() {
             local alias_def="$(eval alias $stash_which 2>/dev/null)"
             if [[ -n $alias_def ]]; then
                 alias_def=${alias_def#alias }
+                alias_def=$(echo "$alias_def" | sed 's/"/\\&/g') # Escape double quotes
                 eval "__varstash_alias__$stash_name=\"$alias_def\""
                 local stashed=1
             fi

--- a/tests/varstash-alias.t
+++ b/tests/varstash-alias.t
@@ -13,9 +13,9 @@ Setup test environment.
 
 Aliases should be stashed.
 
-  $ alias some_alias="echo ORIG_ALIAS"
+  $ alias some_alias='echo "ORIG ALIAS"'
   $ some_alias
-  ORIG_ALIAS
+  ORIG ALIAS
   $ cd .
   ENTER
   $ some_alias
@@ -23,13 +23,13 @@ Aliases should be stashed.
   $ cd ..
   LEAVE
   $ some_alias
-  ORIG_ALIAS
+  ORIG ALIAS
 
 Aliases should be stashed, if there are also environment variables.
 
   $ some_alias=ENV_VAR
   $ some_alias
-  ORIG_ALIAS
+  ORIG ALIAS
   $ cd sub
   ENTER
   $ type -w some_alias


### PR DESCRIPTION
## The problem
`eval "__varstash_alias__$stash_name=\"$alias_def\""` crashes in lib/varstash:111 when I want to stash an alias like `alias some_alias='echo "ORIG ALIAS"'`.

The problem occurs when we have a space inside double quotes in the alias.

## The fix

Escape double quotes.